### PR TITLE
Search enclosing instances of @Nested tests, fixes #129

### DIFF
--- a/junit5/README.md
+++ b/junit5/README.md
@@ -383,6 +383,49 @@ class MyTest {
 }
 ```
 
+#### Nested test classes
+
+A `@Nested` test class can have its own `WeldInitiator` field. If it has, that is the configuration that the nested class
+will use. If the nested class has no `WeldInitiator` field, the enclosing class is queried for *its* `WeldInitiator`
+field and so on until the outermost test class is reached.
+
+```java
+@EnableWeld
+class TestSomeFoo {
+
+    @WeldSetup
+    WeldInitiator weld = WeldInitiator.of(Foo.class);
+
+    @Test
+    void test(Foo myFoo) {
+        assertNotNull(myFoo);
+        assertThrows(UnsatisfiedResolutionException.class, () -> outerWeld.select(Bar.class).get());
+    }
+
+    @Nested
+    class TestSomeNested {
+
+        @Test
+        void testInnerMethodWithOuterWeldContainer(Foo myFoo) {
+            assertNotNull(myFoo);
+        }
+    }
+
+    @Nested
+    class TestSomeOtherNested {
+        
+        @WeldSetup
+        WeldInitiator weld = WeldInitiator.of(Foo.class, Bar.class);
+
+        @Test
+        void testInnerMethodWithInnerWeldContainer(Foo myFoo, Bar myBar) {
+            assertNotNull(myFoo);
+            assertNotNull(myBar);
+        }
+    }
+}
+```
+
 ## WeldJunit5AutoExtension
 
 To use this approach, annotate your test class with `@ExtendWith(WeldJunit5AutoExtension.class)` or just `@EnableAutoWeld`.

--- a/junit5/src/test/java/org/jboss/weld/junit5/initiator/bean/Bar.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/initiator/bean/Bar.java
@@ -1,0 +1,3 @@
+package org.jboss.weld.junit5.initiator.bean;
+
+public class Bar {}

--- a/junit5/src/test/java/org/jboss/weld/junit5/initiator/discovery/NestedClassesWeldInitiatorTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/initiator/discovery/NestedClassesWeldInitiatorTest.java
@@ -1,0 +1,96 @@
+package org.jboss.weld.junit5.initiator.discovery;
+
+import jakarta.inject.Inject;
+import org.jboss.weld.exceptions.UnsatisfiedResolutionException;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.jboss.weld.junit5.initiator.bean.Bar;
+import org.jboss.weld.junit5.initiator.bean.Foo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@EnableWeld
+public class NestedClassesWeldInitiatorTest {
+
+    @WeldSetup
+    private WeldInitiator outerWeld = WeldInitiator.of(Foo.class);
+
+    @Inject
+    Foo outerFoo;
+
+    @Test
+    void testWeldWorksInOuterClass() {
+        Assertions.assertNotNull(outerFoo);
+        Assertions.assertThrows(UnsatisfiedResolutionException.class, () -> outerWeld.select(Bar.class).get());
+    }
+
+    @Nested
+    class NestedWithoutInitiatorTest {
+
+        @Inject
+        Foo innerFoo;
+
+        @Test
+        void testWeldWorksInInnerClass() {
+            Assertions.assertNotNull(outerFoo);
+            Assertions.assertNotNull(innerFoo);
+            Assertions.assertThrows(UnsatisfiedResolutionException.class, () -> outerWeld.select(Bar.class).get());
+        }
+
+        @Nested
+        class TwiceNestedWithoutInitiatorTest {
+
+            @Inject
+            Foo innerInnerFoo;
+
+            @Test
+            void testWeldWorksInSecondInnerClass() {
+                Assertions.assertNotNull(outerFoo);
+                Assertions.assertNotNull(innerFoo);
+                Assertions.assertNotNull(innerInnerFoo);
+                Assertions.assertThrows(UnsatisfiedResolutionException.class, () -> outerWeld.select(Bar.class).get());
+            }
+        }
+    }
+
+    @Nested
+    class NestedWithInitiatorTest {
+
+        @WeldSetup
+        private WeldInitiator innerWeld = WeldInitiator.of(Foo.class, Bar.class);
+
+        @Inject
+        Foo innerFoo;
+
+        @Inject
+        Bar bar;
+
+        @Test
+        void testWeldWorksInInnerClass() {
+            Assertions.assertNotNull(outerFoo);
+            Assertions.assertNotNull(bar);
+        }
+
+        @Nested
+        class TwiceNestedWithoutInitiatorTest {
+
+            @Inject
+            Foo innerInnerFoo;
+
+            @Inject
+            Bar innerBar;
+
+            @Test
+            void testWeldWorksInSecondInnerClass() {
+                Assertions.assertNotNull(outerFoo);
+                Assertions.assertNotNull(innerFoo);
+                Assertions.assertNotNull(innerInnerFoo);
+
+                Assertions.assertNotNull(bar);
+                Assertions.assertNotNull(innerBar);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Modifies the search for WeldInitiator fields so that @Nested test classes will be searched from the inside out until a WeldInitiator is found